### PR TITLE
Chore: Fix Swift6 compile error on tests

### DIFF
--- a/iOSEngineerCodeCheckTests/iOSEngineerCodeCheckTests.swift
+++ b/iOSEngineerCodeCheckTests/iOSEngineerCodeCheckTests.swift
@@ -22,11 +22,4 @@ class iOSEngineerCodeCheckTests: XCTestCase {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
     }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
 }

--- a/iOSEngineerCodeCheckUITests/iOSEngineerCodeCheckUITests.swift
+++ b/iOSEngineerCodeCheckUITests/iOSEngineerCodeCheckUITests.swift
@@ -22,6 +22,7 @@ class iOSEngineerCodeCheckUITests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
+    @MainActor
     func testExample() throws {
         // UI tests must launch the application that they test.
         let app = XCUIApplication()
@@ -29,14 +30,5 @@ class iOSEngineerCodeCheckUITests: XCTestCase {
 
         // Use recording to get started writing UI tests.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testLaunchPerformance() throws {
-        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, *) {
-            // This measures how long it takes to launch your application.
-            measure(metrics: [XCTApplicationLaunchMetric()]) {
-                XCUIApplication().launch()
-            }
-        }
     }
 }


### PR DESCRIPTION
## Describe your changes
- Fix Swift6 compile error on test target:

```swift:
Call to main actor-isolated initializer 'init()' in a synchronous nonisolated context
```

## Issue ticket number and link
#1 
